### PR TITLE
 [#159891068, # 159891068]Fix bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ajv": "^6.5.2",
     "ajv-keywords": "^3.2.0",
     "bootstrap": "^4.1.3",
+    "classnames": "^2.2.6",
     "datatables.net": "^1.10.19",
     "flow-bin": "^0.77.0",
     "jquery": "^3.3.1",

--- a/src/admin/books/add_edit_book.js
+++ b/src/admin/books/add_edit_book.js
@@ -23,6 +23,7 @@ class AddEdit extends Component {
       }
     }
 
+    /** Update state based on user actions in input fields */
     handleChange = (e) => {
       const { id } = e.target;
       let { bookDetails } = this.state;
@@ -32,6 +33,7 @@ class AddEdit extends Component {
       // console.log(bookDetails);
     }
 
+    /** Submit added book data to api endpoint and process response */
     handleSubmit = (e) => {
       e.preventDefault();
       this.setState({ showAlert: false });
@@ -141,7 +143,6 @@ class AddEdit extends Component {
             </select>
             <br />
             <input type="submit" value="save" className="savebook_btn" />
-            <input type="button" value="save and add new" className="addbook_btn" />
           </form>
         </div>
       );

--- a/src/admin/books/add_edit_book.js
+++ b/src/admin/books/add_edit_book.js
@@ -9,7 +9,7 @@ import '../admin.css';
 class AddEdit extends Component {
     state = {
       bookDetails: {
-        title: '', author: '', book_code: 0, ddc_code: '', synopsis: '', genre: '', subgenre: '',
+        title: '', author: '', book_code: Number(), ddc_code: '', synopsis: '', genre: '', subgenre: 'NA',
       },
       showAlert: false,
       errorMessage: '',
@@ -149,10 +149,15 @@ class AddEdit extends Component {
     }
 }
 
+AddEdit.defaultProps = {
+  isHeader: false,
+  details: {},
+};
+
 /** Offers typechecking for the AddEdit component props */
 AddEdit.propTypes = {
-  details: PropTypes.shape().isRequired,
-  isHeader: PropTypes.bool.isRequired,
+  details: PropTypes.shape(),
+  isHeader: PropTypes.bool,
   method: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   history: PropTypes.shape().isRequired,

--- a/src/history/borrow-row.js
+++ b/src/history/borrow-row.js
@@ -64,8 +64,8 @@ class BorrowHistory extends Component {
         <td value={borrow_date}>{borrow_date}</td>
         <td value={due_date}>{due_date}</td>
         <td value={return_date}>{return_date}</td>
-        <td value={fee_owed}>{fee_owed}</td>
-        <td value={status}>{status}</td>
+        <td value={fee_owed} className="fee-cell">{fee_owed}</td>
+        <td value={status} className="status-cell">{status}</td>
         <td hidden={isReturned}>
           <Button onClick={this.toggle}>return</Button>
         </td>

--- a/src/history/borrow-row.js
+++ b/src/history/borrow-row.js
@@ -22,17 +22,23 @@ class BorrowHistory extends Component {
 
   /** Return single book. */
   handleReturn = () => {
-    const { book_id, title, history } = this.props;
+    const {
+      book_id, title, history, updateStateOnReturn,
+    } = this.props;
     const { path } = this.state;
     // Access return book endpoint.
     send({}, 'PUT', path + String(book_id))
       .then(response => (response.json()))
       .then((data) => {
         const msg = data.msg ? data.msg : `Successfully returned: ${title}`;
+        // Update borrowed books table component according to book returned.
+        updateStateOnReturn(data);
+
         // Toggle return modal off.
-        let { returnOpen } = this.state;
+        let { returnOpen, isReturned } = this.state;
         returnOpen = !returnOpen;
-        this.setState({ returnOpen });
+        isReturned = !isReturned;
+        this.setState({ returnOpen, isReturned });
         history.push({ pathname: '/borrow-history' });
         NotificationManager.info(msg, 'Return Book');
       });
@@ -64,7 +70,7 @@ class BorrowHistory extends Component {
           <Button onClick={this.toggle}>return</Button>
         </td>
         {/* Return borrowed book modal */}
-        <Modal isOpen={returnOpen} toggle={this.toggle} className="edit_book_modal">
+        <Modal isOpen={returnOpen} toggle={this.toggle} className="return_book_modal">
           <ModalHeader toggle={this.toggle}>Return Book:</ModalHeader>
           <ModalBody>
             <div>
@@ -75,7 +81,7 @@ class BorrowHistory extends Component {
             <div className="confirm-return">
               <Button
                 onClick={this.handleReturn}
-                style={{ backgroundColor: 'green' }}
+                style={{ backgroundColor: 'green', float: 'right' }}
               >
                 Return
               </Button>
@@ -103,6 +109,7 @@ BorrowHistory.propTypes = {
   fee_owed: PropTypes.number,
   status: PropTypes.string.isRequired,
   history: PropTypes.shape().isRequired,
+  updateStateOnReturn: PropTypes.func.isRequired,
 };
 
 export default withRouter(BorrowHistory);

--- a/src/history/history-borrow.js
+++ b/src/history/history-borrow.js
@@ -4,12 +4,13 @@ import { Table } from 'reactstrap';
 import BorrowRow from './borrow-row';
 import './history.css';
 
-
+/** Borrow history main component.
+ * Displays table with either returned or unreturned books.
+ */
 const BorrowHistory = (props) => {
   const { borrow_details, updateStateOnReturn } = props;
   return (
-    <div className="container body-sec">
-      <h3 className="library-table">Borrowed Books:</h3>
+    <div className="container">
       <Table className="books-table">
         <thead>
           <tr>
@@ -23,6 +24,7 @@ const BorrowHistory = (props) => {
           </tr>
         </thead>
         <tbody>
+          {/* Map each borrow details array aelement to individual borrowed row component */}
           {borrow_details.map(m => (
             <BorrowRow
               key={m.borrow_id}

--- a/src/history/history-borrow.js
+++ b/src/history/history-borrow.js
@@ -6,7 +6,7 @@ import './history.css';
 
 
 const BorrowHistory = (props) => {
-  const { borrow_details } = props;
+  const { borrow_details, updateStateOnReturn } = props;
   return (
     <div className="container body-sec">
       <h3 className="library-table">Borrowed Books:</h3>
@@ -34,6 +34,7 @@ const BorrowHistory = (props) => {
               return_date={m.return_date}
               fee_owed={m.fee_owed}
               status={m.status}
+              updateStateOnReturn={updateStateOnReturn}
             />))}
         </tbody>
       </Table>
@@ -43,6 +44,7 @@ const BorrowHistory = (props) => {
 
 BorrowHistory.propTypes = {
   borrow_details: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  updateStateOnReturn: PropTypes.func.isRequired,
 };
 
 export default BorrowHistory;

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -1,0 +1,14 @@
+.nav-tabs .nav-item>a{
+    padding: 3px;
+    font-size: 12px;
+}
+
+.nav-tabs .nav-item> .active {
+    border-width: 3px;
+    border-left: 5px solid tomato;
+    color: tomato;
+}
+
+.fee-cell, .status-cell {
+    text-align: center;
+}

--- a/src/history/history.js
+++ b/src/history/history.js
@@ -21,13 +21,27 @@ class Home extends Component {
       });
   }
 
+  /** Update borrowed book component based on returned book. */
+  updateStateOnReturn = (data) => {
+    const { borrow_details } = this.state;
+    // Get index of returned book in this.state.borrow_details and update the element at said index.
+    let returned_book = borrow_details.filter(detail => detail.borrow_id === data.borrow_id)[0];
+    returned_book = Object.assign(returned_book,
+      { return_date: data.return_date, fee_owed: data.fee_owed, status: data.status });
+    const index_returned = borrow_details.indexOf(returned_book);
+    borrow_details[index_returned] = returned_book;
+    this.setState({ borrow_details });
+  }
+
   render() {
     const { borrow_details } = this.state;
-    console.log(borrow_details);
 
     return (
       <div>
-        <BorrowHistory borrow_details={borrow_details} />
+        <BorrowHistory
+          borrow_details={borrow_details}
+          updateStateOnReturn={this.updateStateOnReturn}
+        />
       </div>
     );
   }

--- a/src/history/history.js
+++ b/src/history/history.js
@@ -1,12 +1,24 @@
+/** ./src/history/history.js
+ * Parent user borrow hstory component.
+ * It can be accessed via the  history link in the main navbar dropdown menu.
+ */
+
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import {
+  Nav, NavItem, NavLink, TabContent, TabPane,
+} from 'reactstrap';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import send, { sessionExpire } from '../Helpers';
 import BorrowHistory from './history-borrow';
 import './history.css';
 
+/** Main user borrow history component.
+ * All api fetches called from this component.
+*/
 class Home extends Component {
-  state = { borrow_details: [] }
+  state = { borrow_details: [], activeTab: 'unreturned' }
 
   componentDidMount = () => {
     const { history } = this.props;
@@ -21,7 +33,9 @@ class Home extends Component {
       });
   }
 
-  /** Update borrowed book component based on returned book. */
+  /** Update borrowed book component based on returned book.
+   * @param {object} data
+  */
   updateStateOnReturn = (data) => {
     const { borrow_details } = this.state;
     // Get index of returned book in this.state.borrow_details and update the element at said index.
@@ -33,15 +47,53 @@ class Home extends Component {
     this.setState({ borrow_details });
   }
 
+  /** Toggle between returned and unreturned book tabs.
+   * @param {string} tab
+  */
+  toggle = (tab) => {
+    let { activeTab } = this.state;
+    activeTab = activeTab !== tab ? tab : activeTab;
+    this.setState({ activeTab });
+  }
+
   render() {
-    const { borrow_details } = this.state;
+    const { borrow_details, activeTab } = this.state;
 
     return (
-      <div>
-        <BorrowHistory
-          borrow_details={borrow_details}
-          updateStateOnReturn={this.updateStateOnReturn}
-        />
+      <div className="container body-sec">
+        <h3 className="library-table">Borrowed Books:</h3>
+        <Nav tabs>
+          <NavItem>
+            <NavLink
+              className={classnames({ active: activeTab === 'unreturned' })}
+              onClick={() => { this.toggle('unreturned'); }}
+            >
+              unreturned
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink
+              className={classnames({ active: activeTab === 'returned' })}
+              onClick={() => { this.toggle('returned'); }}
+            >
+              returned
+            </NavLink>
+          </NavItem>
+        </Nav>
+        <TabContent activeTab={activeTab}>
+          <TabPane tabId="unreturned">
+            <BorrowHistory
+              borrow_details={borrow_details.filter(borrow => borrow.status !== 'returned')}
+              updateStateOnReturn={this.updateStateOnReturn}
+            />
+          </TabPane>
+          <TabPane tabId="returned">
+            <BorrowHistory
+              borrow_details={borrow_details.filter(borrow => borrow.status === 'returned')}
+              updateStateOnReturn={this.updateStateOnReturn}
+            />
+          </TabPane>
+        </TabContent>
       </div>
     );
   }

--- a/src/home/books/bookrow.js
+++ b/src/home/books/bookrow.js
@@ -32,7 +32,7 @@ class BookRow extends Component {
         .then(response => (response.json()))
         .then((data) => {
           const msg = data.msg ? data.msg : `Successfully borrowed: ${title}. Return Date: ${data.due_date}`;
-          history.push({ pathname: '/home' });
+          history.push({ pathname: '/borrow-history' });
           show.borrow = !show.borrow;
           this.setState({ show });
           NotificationManager.info(msg, 'Borrow Book');
@@ -152,13 +152,14 @@ class BookRow extends Component {
             <ModalBody>
               <div>
                 <p> Are you sure you want to delete
-                  <span> { title } ?</span>
+                  <span> { title }</span>?
+                  <p>Author: <span> { author } </span></p>
                 </p>
               </div>
               <div className="confirm-delete">
                 <Button
                   onClick={this.handleDelete}
-                  style={{ backgroundColor: 'red' }}
+                  style={{ backgroundColor: '#d9534f' }}
                 >
                   Delete
                 </Button>
@@ -178,7 +179,7 @@ class BookRow extends Component {
               <div className="confirm-borrow">
                 <Button
                   onClick={this.handleBorrow}
-                  style={{ backgroundColor: 'blue', float: 'right' }}
+                  style={{ backgroundColor: '#337ab7', float: 'right' }}
                 >
                   Borrow
                 </Button>

--- a/src/home/books/bookrow.js
+++ b/src/home/books/bookrow.js
@@ -156,8 +156,9 @@ class BookRow extends Component {
             <ModalBody>
               <div>
                 <p> Are you sure you want to delete
-                  <span> { title }</span>?
-                  <p>Author: <span> { author } </span></p>
+                  <span> { title }</span>?<br />
+                  author: <span> { author } </span><br />
+                  book code: <span> { book_code } </span>
                 </p>
               </div>
               <div className="confirm-delete">

--- a/src/home/books/bookrow.js
+++ b/src/home/books/bookrow.js
@@ -22,7 +22,9 @@ class BookRow extends Component {
       method: 'PUT',
     }
 
-    /** Borrow single book */
+    /** Borrow single book
+     * @memberof BookRow
+     */
     handleBorrow = () => {
       const { value, title, history } = this.props;
       const { path_borrow } = this.state;
@@ -39,7 +41,9 @@ class BookRow extends Component {
         });
     }
 
-    /** Delete single book entry */
+    /** Delete single book entry
+     * @memberof BookRow
+     */
     handleDelete = () => {
       const { value, title } = this.props;
       const { path } = this.state;

--- a/src/home/books/bookrow.js
+++ b/src/home/books/bookrow.js
@@ -178,7 +178,7 @@ class BookRow extends Component {
               <div className="confirm-borrow">
                 <Button
                   onClick={this.handleBorrow}
-                  style={{ backgroundColor: 'blue' }}
+                  style={{ backgroundColor: 'blue', float: 'right' }}
                 >
                   Borrow
                 </Button>
@@ -187,7 +187,7 @@ class BookRow extends Component {
           </Modal>
 
           {/* Show more book details */}
-          <Modal isOpen={show.deleteModal} toggle={this.toggle} className="show_book_details_modal">
+          <Modal isOpen={show.moreDetailsModal} toggle={this.toggle} className="show_book_details_modal">
             <ModalHeader toggle={this.toggle}>{title}</ModalHeader>
             <ModalBody>
               <div>

--- a/src/home/books/books.js
+++ b/src/home/books/books.js
@@ -28,8 +28,7 @@ class Books extends Component {
           <h3 className="library-table">Library</h3>
           <div className="table-ctrl">
             <form className="search-form">
-              <input type="text" placeholder="search author/title" onChange={handleChange} />
-              {/* <Button type="submit" className="search-book fa fa-search" /> */}
+              <input type="text" placeholder="&#xF002; search author/title" onChange={handleChange} style={{ fontFamily: 'Arial, FontAwesome' }} />
             </form>
 
             {/* Page element consisting of buttons that load corresponding results */}

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -1,7 +1,6 @@
 /** Main home component */
 
 import React, { Component } from 'react';
-import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import send, { sessionExpire } from '../Helpers';
 import Books from './books/books';
@@ -57,6 +56,7 @@ class Home extends Component {
   render() {
     const { results, isSearch } = this.state;
     const page_list = Array.from({ length: results.pages }, (v, k) => k + 1);
+    console.log('checking props ', this.props);
 
     return (
       <div>
@@ -91,4 +91,4 @@ Home.propTypes = {
   history: PropTypes.shape().isRequired,
 };
 
-export default withRouter(Home);
+export default Home;

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -56,7 +56,6 @@ class Home extends Component {
   render() {
     const { results, isSearch } = this.state;
     const page_list = Array.from({ length: results.pages }, (v, k) => k + 1);
-    console.log('checking props ', this.props);
 
     return (
       <div>

--- a/src/index.css
+++ b/src/index.css
@@ -283,28 +283,16 @@ updatebook-sec {
     cursor: pointer;
     font-size: 15px;
 }
-.savebook_btn,
-.addbook_btn,
-.deletebook_btn {
+.savebook_btn {
     border-radius: 10px;
     border: none;
-}
-.savebook_btn:hover,
-.addbook_btn:hover,
-.deletebook_btn:hover {
-    cursor: pointer;
-    font-size: 18px;
-}
-.savebook_btn:hover{
-    color:tomato;
-}
-.addbook_btn{
     background: tomato;
     color: white;
 }
-.deletebook_btn{
-    background: red;
-    color: white;
+.savebook_btn:hover {
+    cursor: pointer;
+    font-size: 18px;
+    color: black;
 }
 
 /*addbook*/


### PR DESCRIPTION
### What does this PR do?
It adds support for separation of returned and unreturned books
Some fixed bugs include:
 - Edit book fail if book_code not edited
 - Component auto update on book return failure

### How can it be manually tested?
Once a user is logged in and they access their borrow history page, they should be able to view separate tabs for unreturned(default) and returned books. Furthermore, if they return a book, they should not need to manually refresh the page for the corresponding borrowed book entry to be updated.
A logged in admin should also be able to edit a book without having to edit optional items such as sub-genre or synopsis